### PR TITLE
feat: 列内排序新增「按标题」；修复下拉弹出列表深色主题下白底浅字不可读

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -275,7 +275,7 @@ window.__ModuleLoader__.load({
 					sortBy: "default"
 				};
 				const parsed = JSON.parse(raw);
-				const sortBy = parsed.sortBy === "updated" || parsed.sortBy === "urgency" || parsed.sortBy === "created" ? parsed.sortBy : "default";
+				const sortBy = parsed.sortBy === "updated" || parsed.sortBy === "urgency" || parsed.sortBy === "created" || parsed.sortBy === "title" ? parsed.sortBy : "default";
 				return {
 					workspaceId: typeof parsed.workspaceId === "string" ? parsed.workspaceId : void 0,
 					urgencies: Array.isArray(parsed.urgencies) ? parsed.urgencies.filter((u) => u === "urgent" || u === "normal" || u === "relaxed") : [],
@@ -1054,6 +1054,12 @@ window.__ModuleLoader__.load({
 		  border: 1px solid var(--dsw-border, rgba(128,128,128,.35));
 		  background: var(--dsw-bg, transparent); color: inherit;
 		}
+		.dsh-atb-select { color-scheme: dark; }
+		.dsh-atb-select option {
+		  background-color: #24242a;
+		  color: #e8e8ea;
+		}
+		.dsh-atb-select option:checked { background-color: #3a3a44; }
 		.dsh-atb-chip {
 		  display: inline-flex; align-items: center; gap: 5px;
 		  font-size: 12px; padding: 3px 9px; border-radius: 999px; cursor: pointer;
@@ -4337,6 +4343,7 @@ window.__ModuleLoader__.load({
 			if (state.sortBy === "updated") sorted.sort((a, b) => b.updatedAt - a.updatedAt);
 			else if (state.sortBy === "created") sorted.sort((a, b) => b.createdAt - a.createdAt);
 			else if (state.sortBy === "urgency") sorted.sort((a, b) => URGENCY_RANK[a.urgency] - URGENCY_RANK[b.urgency] || b.updatedAt - a.updatedAt);
+			else if (state.sortBy === "title") sorted.sort((a, b) => a.title.localeCompare(b.title, void 0, { numeric: true }));
 			return sorted;
 		}
 		/**
@@ -4466,6 +4473,10 @@ window.__ModuleLoader__.load({
 									/* @__PURE__ */ (0, react_jsx_runtime.jsx)("option", {
 										value: "created",
 										children: "创建时间"
+									}),
+									/* @__PURE__ */ (0, react_jsx_runtime.jsx)("option", {
+										value: "title",
+										children: "按标题"
 									})
 								]
 							}),

--- a/src/client/board/TaskBoard.tsx
+++ b/src/client/board/TaskBoard.tsx
@@ -34,6 +34,7 @@ export function filterTasks(state: ControllerState, tasks: TaskRecord[]): TaskRe
   if (state.sortBy === 'updated') sorted.sort((a, b) => b.updatedAt - a.updatedAt)
   else if (state.sortBy === 'created') sorted.sort((a, b) => b.createdAt - a.createdAt)
   else if (state.sortBy === 'urgency') sorted.sort((a, b) => URGENCY_RANK[a.urgency] - URGENCY_RANK[b.urgency] || b.updatedAt - a.updatedAt)
+  else if (state.sortBy === 'title') sorted.sort((a, b) => a.title.localeCompare(b.title, undefined, { numeric: true }))
   return sorted
 }
 
@@ -128,6 +129,7 @@ export function TaskBoard({ controller }: { controller: BoardController }) {
           <option value="updated">最近更新</option>
           <option value="urgency">按紧急度</option>
           <option value="created">创建时间</option>
+          <option value="title">按标题</option>
         </select>
         {(['urgent', 'normal', 'relaxed'] as const).map(u => (
           <button

--- a/src/client/controller.ts
+++ b/src/client/controller.ts
@@ -22,7 +22,7 @@ export interface BoardFilters {
 }
 
 /** Column sort orders. */
-export type SortBy = 'default' | 'updated' | 'urgency' | 'created'
+export type SortBy = 'default' | 'updated' | 'urgency' | 'created' | 'title'
 
 /** localStorage key for persisted view state (filters + sort). */
 const VIEW_KEY = 'dsh-taskboard-view-v1'
@@ -33,7 +33,7 @@ function loadView(): { workspaceId?: string; urgencies: Urgency[]; sortBy: SortB
     const raw = localStorage.getItem(VIEW_KEY)
     if (raw === null) return { urgencies: [], sortBy: 'default' }
     const parsed = JSON.parse(raw) as { workspaceId?: string; urgencies?: Urgency[]; sortBy?: SortBy }
-    const sortBy = parsed.sortBy === 'updated' || parsed.sortBy === 'urgency' || parsed.sortBy === 'created' ? parsed.sortBy : 'default'
+    const sortBy = parsed.sortBy === 'updated' || parsed.sortBy === 'urgency' || parsed.sortBy === 'created' || parsed.sortBy === 'title' ? parsed.sortBy : 'default'
     return {
       workspaceId: typeof parsed.workspaceId === 'string' ? parsed.workspaceId : undefined,
       urgencies: Array.isArray(parsed.urgencies) ? parsed.urgencies.filter(u => u === 'urgent' || u === 'normal' || u === 'relaxed') : [],

--- a/src/client/styles.ts
+++ b/src/client/styles.ts
@@ -96,6 +96,16 @@ html[data-dsh-atb-active] .dsh-atb-view { display: flex; flex-direction: column;
   border: 1px solid var(--dsw-border, rgba(128,128,128,.35));
   background: var(--dsw-bg, transparent); color: inherit;
 }
+/* Native <option> popups ignore page styles unless forced, and no theme
+   defines the --dsw-* tokens yet — bind the open list to explicit opaque
+   dark colors (this deployment runs dark skins) plus color-scheme:dark so
+   Chromium paints the popup chrome dark too. Readability beats theming. */
+.dsh-atb-select { color-scheme: dark; }
+.dsh-atb-select option {
+  background-color: #24242a;
+  color: #e8e8ea;
+}
+.dsh-atb-select option:checked { background-color: #3a3a44; }
 .dsh-atb-chip {
   display: inline-flex; align-items: center; gap: 5px;
   font-size: 12px; padding: 3px 9px; border-radius: 999px; cursor: pointer;


### PR DESCRIPTION
## 背景

在真实使用中碰到两个体验问题（v0.5.1，Windows / 深色皮肤）：

### 1. 没有「按标题」排序

列内排序目前是 `默认排序 / 最近更新 / 按紧急度 / 创建时间`。「默认」= 建卡顺序，
当我用 `01~17` 时间线数字前缀命名卡片时，改标题完全不影响显示顺序——板上任务
希望按一天的执行时间线走，只能靠数字前缀+标题排序实现。

### 2. 下拉框弹出列表白底浅字不可读

关闭状态的下拉框样式正常（`.dsh-atb-select` 套了主题变量），但点开后的原生
`<option>` 弹出列表不吃页面任何样式：Chromium 给默认白底，字色却继承界面的浅色，
深色界面下几乎看不见选项。另外核查了主样式表与皮肤层，`--dsw-bg-elevated`
等令牌当前**没有任何地方定义**，所以 `var(--dsw-*, fallback)` 的兜底值（白色）
反而会稳定生效——靠令牌救不了这个场景。

## 改动（+26 −3，4 文件）

| 文件 | 内容 |
|---|---|
| `src/client/controller.ts` | `SortBy` 加 `'title'`；`loadView` 白名单同步，旧 localStorage 值安全回落 default |
| `src/client/board/TaskBoard.tsx` | `filterTasks` 增加 numeric-aware 比较；工具栏下拉新增「按标题」|
| `src/client/styles.ts` | `.dsh-atb-select { color-scheme: dark }` + `option` 显式不透明深色配色、`:checked` 高亮；注释说明了为何暂时硬编码 |
| `lib/client.js` | 编译产物同步（仓库约定 lib 随源码提交，github: 安装免构建） |

## 设计取舍说明

- **numeric: true**：卡片标题大量使用数字前缀（01~91），字符串比较会把 `10` 排到
  `02` 前面，必须数值感知。
- **弹层硬编码深色而不是 var() 兜底**：可读性优先于自动跟肤。现在没有任何主题定义
  `--dsw-*`，兜底路径必然落白底；等令牌体系真正落地后这批规则可以自然交还变量。
  深浅双主题自适应的更完整做法欢迎维护者定夺，若方向不对我可以改。

## 自验

- [x] `node --check lib/client.js` 通过
- [x] 本地实例替换后热生效：弹出列表深底亮字、选中项高亮正常（含项目筛选下拉，同一类名一并受益）
- [x] 19 张带数字前缀的卡片切换「按标题」后严格按 01<02<…<17<90<91 显示
- [x] 未选「按标题」时行为与原先一致（default/updated/urgency/created 四项不受影响）